### PR TITLE
Update to PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpdocumentor/reflection-docblock": "^3.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.5"
+        "phpunit/phpunit": "^6.4"
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
As we support `PHP 7`, let's update our suite of tests to `PHPUnit 6`.